### PR TITLE
Allow 'exports' key

### DIFF
--- a/src/rollup.js
+++ b/src/rollup.js
@@ -13,6 +13,7 @@ const ALLOWED_KEYS = [
 	'dest',
 	'entry',
 	'external',
+	'exports',
 	'footer',
 	'format',
 	'globals',


### PR DESCRIPTION
Apparently this option isn't used much, but we need it whitelisted to integrate properly with gulp-rollup.
